### PR TITLE
Wrap the telephone number in an anchor tag in the index.html

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
 
     <footer>
         <div class="questions">
-            Questions? Call 000-800-919-1694
+            Questions? Call:  <b><a href="tel:0008009191694" style="color: #2f72ee;">000-800-919-1694</a></b>
         </div>
         <div class="footer">
 


### PR DESCRIPTION
Problem:
The telephone number in the footer is currently displayed as plain text, requiring users to manually dial the number rather than tapping to call directly on mobile devices.

Solution:
Wrap the number in an anchor tag with href="tel:0008009191694". This change will allow users to simply tap the number to initiate a call, enhancing usability on devices with calling capabilities.
